### PR TITLE
Slight change for latest update to support Linux compiles

### DIFF
--- a/src/sdksentry/sdksentry.cpp
+++ b/src/sdksentry/sdksentry.cpp
@@ -175,6 +175,14 @@ void CSentry::Shutdown()
      #include <SDL.h>
 #endif
 
+#ifndef _WIN32
+#define __debugbreak() \
+    asm("0:"                              \
+        ".pushsection embed-breakpoints;" \
+        ".quad 0b;"                       \
+        ".popsection;")
+#endif
+
 
 
 // we do this because sentry has stupid weird behavior
@@ -347,7 +355,11 @@ void InternalError_CB(InternalError_vars)
     sentry_value_set_by_key(event, "logger", sentry_value_new_string(__FUNCTION__));
     sentry_value_set_by_key(event, "message", sentry_value_new_string(errFmt.c_str()));
 
-    sentry_value_t thread = sentry_value_new_thread(GetCurrentThreadId(), "nada");
+#ifndef _WIN32
+    sentry_value_t thread = sentry_value_new_thread(pthread_self(), "nada");
+#else
+	sentry_value_t thread = sentry_value_new_thread(GetCurrentThreadId(), "nada");
+#endif
     sentry_value_set_stacktrace(thread, NULL, 16);
     sentry_event_add_thread(event, thread);
 

--- a/src/sdksentry/sdksentry.cpp
+++ b/src/sdksentry/sdksentry.cpp
@@ -181,13 +181,23 @@ void CSentry::Shutdown()
 // where we can
 // a) call sentry_shutdown() and the crash handler still gets called
 // b) crash multiple times and call its own crash handler - i.e. this function is reentrant!
+#ifdef _WIN32
 #define explodeImmediately()                \
     __debugbreak();                         \
     __fastfail(FAST_FAIL_FATAL_APP_EXIT);   \
                                             \
     sentry_value_decref(event);             \
     return sentry_value_new_null();
-
+#else
+// LINUX SUPPORT:
+//  _exit(2) closes the process "immediately", similary to fastfail, but more universal
+#define explodeImmediately()                \
+    __debugbreak();                         \
+    _exit(2);                               \
+                                            \
+    sentry_value_decref(event);             \
+    return sentry_value_new_null();
+#endif
 // DO NOT THREAD THIS OR ANY FUNCTIONS CALLED BY IT UNDER ANY CIRCUMSTANCES
 // THIS NEEDS TO BE SIGNAL SAFE ALSO
 // I MEAN NOT REALLY ON WINDOWS ITS CALLED IN A SEH BUT

--- a/src/sdksentry/sdksentry.h
+++ b/src/sdksentry/sdksentry.h
@@ -22,9 +22,9 @@ class CSentry : public CAutoGameSystem
 public:
     CSentry();
 
-    std::atomic_bool    didinit;
-    std::atomic_bool    didshutdown;
-    std::atomic_bool    crashed;
+    std::atomic<bool>    didinit;
+    std::atomic<bool>    didshutdown;
+    std::atomic<bool>    crashed;
     volatile sig_atomic_t    sentryLogFilePtr;
     volatile sig_atomic_t    conFileFilePtr;
 


### PR DESCRIPTION
Changed "atomic_bool" macro to directly defining atomic<bool>, as it doesn't work correctly on linux
Added a univesal explodeImmediately using _exit(2) if not compiling for Windows