### PR TITLE
fix downstream builds, add wstring split UTIL

### DIFF
--- a/src/helpers/inc_cpp_stdlib.h
+++ b/src/helpers/inc_cpp_stdlib.h
@@ -28,15 +28,6 @@
 #include <type_traits>
 #include <chrono>
 #include <vector>
-
-template <typename T>
-void Vector_FindAndRemove(std::vector<T>& v, T item)
-{
-    v.erase(std::remove(v.begin(), v.end(), item), v.end());
-}
-
-
-
 #include <string>
 #include <sstream>
 #include <memory>
@@ -50,6 +41,12 @@ void Vector_FindAndRemove(std::vector<T>& v, T item)
 #include <unordered_set>
 #include <map>
 #include <bitset>
+
+template <typename T>
+void Vector_FindAndRemove(std::vector<T>& v, T item)
+{
+    v.erase(std::remove(v.begin(), v.end(), item), v.end());
+}
 
 #define FMT_ENFORCE_COMPILE_STRING
 #include <fmt/format.h>

--- a/src/helpers/misc_helpers.cpp
+++ b/src/helpers/misc_helpers.cpp
@@ -215,6 +215,21 @@ std::vector<std::string> UTIL_SplitSTDString(const std::string& i_str, const std
 	return result;
 }
 
+std::vector<std::wstring> UTIL_SplitSTDWString(const std::wstring& i_str, const std::wstring& i_delim)
+{
+	std::vector<std::wstring> result;
+	size_t startIndex = 0;
+
+	for (size_t found = i_str.find(i_delim); found != std::string::npos; found = i_str.find(i_delim, startIndex))
+	{
+		result.emplace_back(i_str.begin() + startIndex, i_str.begin() + found);
+		startIndex = found + i_delim.size();
+	}
+	if (startIndex != i_str.size())
+		result.emplace_back(i_str.begin() + startIndex, i_str.end());
+	return result;
+}
+
 std::string UTIL_StripCharsFromSTDString(std::string i_str, char char_to_strip)
 { 
 	i_str.erase(std::remove(i_str.begin(), i_str.end(), char_to_strip), i_str.end());

--- a/src/helpers/misc_helpers.h
+++ b/src/helpers/misc_helpers.h
@@ -40,8 +40,8 @@ std::string UTIL_AddrToString(void* inAddr);
 
 
 // https://stackoverflow.com/a/57346888
-//
 std::vector<std::string> UTIL_SplitSTDString(const std::string& i_str, const std::string& i_delim);
+std::vector<std::wstring> UTIL_SplitSTDWString(const std::wstring& i_str, const std::wstring& i_delim);
 std::string UTIL_StripCharsFromSTDString(std::string i_str, char char_to_strip);
 std::string& UTIL_ReplaceAll(std::string& context, std::string const& from, std::string const& to);
 


### PR DESCRIPTION
- Moves declaration of `Vector_FindAndRemove` to occur after `#include <algorithm>` which currently breaks builds downstream (for Open Fortress, for example).
- Adds a UTIL function for splitting `std::wstring` into a vector which is 1-to-1 with the `std::string` split util. Could make this templated instead, open to feedback there.