### PR TITLE
Remove exception handler on shutdown

### DIFF
--- a/src/sdksentry/sdksentry.cpp
+++ b/src/sdksentry/sdksentry.cpp
@@ -195,6 +195,8 @@ void CSentry::Shutdown()
     sentry_close();
     didshutdown.store(true);
 
+    RemoveVectoredExceptionHandler(vec_handler_handle);
+
 #ifdef _WIN32
     SetUnhandledExceptionFilter(NULL);
 #endif
@@ -551,8 +553,8 @@ void CSentry::SentryInit()
         return;
     }
 
-    SetMiniDumpFunction(MINI);
-    AddVectoredExceptionHandler(1 /* first handler */, VecXceptionHandler);
+    //SetMiniDumpFunction(MINI);
+    vec_handler_handle = AddVectoredExceptionHandler(1 /* first handler */, VecXceptionHandler);
 
     const char* mpath = ConVarRef("_modpath", false).GetString();
     if (!mpath)

--- a/src/sdksentry/sdksentry.h
+++ b/src/sdksentry/sdksentry.h
@@ -41,6 +41,8 @@ public:
 
     volatile char* cmdline = nullptr;
 
+    PVOID vec_handler_handle = nullptr;
+
 
     void                PostInit() override;
     void                Shutdown() override;


### PR DESCRIPTION
This fixes an oversight where CSentry calls AddVectoredExceptionHandler on init but doesn't call RemoveVectoredExceptionHandler on shutdown. Since the exception handler never gets removed, this means that if you get an exception after game dll got unloaded, you'll get infinite exception loop with the code trying to call exception handler from an unloaded module and triggering an exception again.
I've also commented out SetMiniDumpFunction since you'll likely get a similar issue if Valve's WriteMinidump function gets called in the same scenario.